### PR TITLE
Fix navigation link when app is in extra apps_path

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,17 +42,6 @@ Die Zielzeit ist ein einheitlicher Tageswert, wodurch sie sich besonders für kl
 		<nextcloud min-version="30" max-version="32"/>
 	</dependencies>
 
-	<navigations>
-    <navigation>
-      <id>timesheet</id>
-      <name>Timesheet</name>
-      <route>timesheet.page.index</route>
-      <order>10</order>
-      <icon>app.svg</icon>
-      <type>link</type>
-    </navigation>
-  </navigations>
-
 	<settings>
 		<admin>OCA\Timesheet\Settings\AdminSettings</admin>
 		<admin-section>OCA\Timesheet\Settings\AdminSection</admin-section>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -7,6 +7,9 @@ use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\BackgroundJob\IJobList;
+use OCP\INavigationManager;
+use OCP\IURLGenerator;
+use OCP\L10N\IFactory;
 use OCA\Timesheet\BackgroundJob\HrNotificationJob;
 
 class Application extends App implements IBootstrap {
@@ -26,6 +29,21 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
+		$context->injectFn(function (INavigationManager $navigationManager, IURLGenerator $urlGenerator, IFactory $l10nFactory) {
+			$appId = self::APP_ID;
+			$navigationManager->add(function () use ($appId, $urlGenerator, $l10nFactory) {
+				$l = $l10nFactory->get($appId);
+				return [
+					'id' => $appId,
+					'order' => 10,
+					'href' => $urlGenerator->linkToRoute($appId . '.page.index'),
+					'icon' => $urlGenerator->imagePath($appId, 'app.svg'),
+					'name' => $l->t('Timesheet'),
+					'app' => $appId,
+				];
+			});
+		});
+
 		$server = $context->getServerContainer();
 
 		/** @var IJobList $jobList */


### PR DESCRIPTION
Registered the Timesheet menu entry via INavigationManager at boot and removed the info.xml navigation entry so the route is resolved after the app is loaded, which avoids broken hrefs on multi apps_paths setups.